### PR TITLE
Revert "Experiment with previousName"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,8 +16,6 @@
       color: 207de5
     - name: help wanted
       color: "159818"
-      previousNames:
-        - temporary test label
     - name: in progress
       color: fbca04
     - name: invalid


### PR DESCRIPTION
Reverts StackStorm/github-meta#9

Apparently, `previousNames` and `name` label can't exist at the same time. Should definitely treat this function with caution.